### PR TITLE
Fix typo in Phoenix Light.sublime-theme that broke ST2

### DIFF
--- a/Phoenix Light.sublime-theme
+++ b/Phoenix Light.sublime-theme
@@ -1600,6 +1600,6 @@
     {
         "class": "icon_folder_loading",
         "content_margin": [0,0]
-    },
+    }
 
 ]


### PR DESCRIPTION
The trailing comma breaks the theme in Sublime Text 2. See the discussion at

  https://github.com/netatoo/phoenix-theme/pull/37#commitcomment-7691096
